### PR TITLE
Null check for player in TooltipEventHandler

### DIFF
--- a/src/main/java/pers/towdium/just_enough_calculation/event/TooltipEventHandler.java
+++ b/src/main/java/pers/towdium/just_enough_calculation/event/TooltipEventHandler.java
@@ -21,7 +21,7 @@ public class TooltipEventHandler {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onTooltip(ItemTooltipEvent event) {
-        if (event.getEntityPlayer().openContainer instanceof GuiPickerFluid.ContainerPickerFluid) {
+        if (event.getEntityPlayer() != null && event.getEntityPlayer().openContainer instanceof GuiPickerFluid.ContainerPickerFluid) {
             Iterator<String> i = event.getToolTip().iterator();
             String str;
             Matcher matcher = null;


### PR DESCRIPTION
The EntityPlayer from the event is not explicitly specified as Nonnull and I've had stacktraces caused by NullPointerExceptions from "event.getEntityPlayer()" in ItemTooltipEvent handlers on occasion, so I feel like there should be a null check just in case.
