### PR TITLE
Changed the protocol version to something less likely to conflict wit…

### DIFF
--- a/src/main/java/me/towdium/jecalculation/JustEnoughCalculation.java
+++ b/src/main/java/me/towdium/jecalculation/JustEnoughCalculation.java
@@ -38,7 +38,7 @@ import static net.minecraftforge.fml.network.NetworkRegistry.ABSENT;
 public class JustEnoughCalculation {
     public static final String MODID = "jecalculation";
     public static final String MODNAME = "Just Enough Calculation";
-    public static final String PROTOCOL = "1";
+    public static final String PROTOCOL = "JUST_ENOUGH_CALCULATION_1";
     public static SimpleChannel network;
     public static Logger logger = LogManager.getLogger(MODID);
 
@@ -57,9 +57,10 @@ public class JustEnoughCalculation {
     @SubscribeEvent
     public static void setupCommon(FMLCommonSetupEvent event) {
         network = NetworkRegistry.newSimpleChannel(
-                new ResourceLocation(MODID, "main"), () -> PROTOCOL,
-                v -> v.equals(PROTOCOL) || v.equals(ABSENT),
-                v -> v.equals(PROTOCOL) || v.equals(ABSENT)
+            new ResourceLocation(MODID, "main"),
+            () -> PROTOCOL,
+            v -> v.equals(PROTOCOL) || v.equals(ABSENT),
+            v -> v.equals(PROTOCOL) || v.equals(ABSENT)
         );
         network.registerMessage(0, PCalculator.class, PCalculator::write, PCalculator::new, PCalculator::handle);
         network.registerMessage(1, PEdit.class, PEdit::write, PEdit::new, PEdit::handle);


### PR DESCRIPTION
Changed the protocol version to something less likely to conflict with other mods.

Apperently JEC conflicts with the Electrodynamics mod.

Here's what I think happened:
[Relevant JEC code](https://github.com/Towdium/JustEnoughCalculation/blob/1.16/src/main/java/me/towdium/jecalculation/JustEnoughCalculation.java#L41)
[Relevant Electrodynamics code](https://github.com/aurilisdev/Electrodynamics/blob/1.16.5/src/main/java/electrodynamics/common/packet/NetworkHandler.java#L14)

It look like both mods define the same protocol version `"1"` (probably something from a tutorial?). Apparently that makes the mods conflict for some reason (the crafting calculator becomes unusable, because something goes wrong with defining packet definitions). Changing this fixes the apparent conflict.

No idea if this breaks client-only mode, it shouldn't.

