### PR TITLE
Two fixes to calculator widget

### DIFF
--- a/common/src/main/java/me/towdium/jecalculation/events/GuiScreenOverlayHandler.java
+++ b/common/src/main/java/me/towdium/jecalculation/events/GuiScreenOverlayHandler.java
@@ -2,6 +2,7 @@ package me.towdium.jecalculation.events;
 
 import com.google.common.collect.Comparators;
 import me.towdium.jecalculation.JecaItem;
+import me.towdium.jecalculation.data.Controller;
 import me.towdium.jecalculation.gui.JecaGui;
 import me.towdium.jecalculation.gui.guis.GuiCraftMini;
 import me.towdium.jecalculation.gui.guis.IGui;
@@ -67,13 +68,27 @@ public class GuiScreenOverlayHandler extends WContainer implements IGui {
 
     public List<GuiCraftMini> inventoryToWidgets(Inventory inventory) {
         List<GuiCraftMini> results = new ArrayList<>();
-        for (int i = 0; i < inventory.items.size(); i++) {
-            ItemStack itemStack = inventory.items.get(i);
-            if (itemStack.getItem() == JecaItem.CRAFT.get()) {
-                GuiCraftMini widget = new GuiCraftMini(itemStack, i);
-                if (widget.record.overlayOpen) {
-                    results.add(widget);
+        if (Controller.isServerActive())
+        {
+            for (int i = 0; i < inventory.items.size(); i++)
+            {
+                ItemStack itemStack = inventory.items.get(i);
+                if (itemStack.getItem() == JecaItem.CRAFT.get())
+                {
+                    GuiCraftMini widget = new GuiCraftMini(itemStack, i);
+                    if (widget.record.overlayOpen)
+                    {
+                        results.add(widget);
+                    }
                 }
+            }
+        }
+        else
+        {
+            GuiCraftMini widget = new GuiCraftMini(null, 0);
+            if (widget.record.overlayOpen)
+            {
+                results.add(widget);
             }
         }
         return results;

--- a/common/src/main/java/me/towdium/jecalculation/events/GuiScreenOverlayHandler.java
+++ b/common/src/main/java/me/towdium/jecalculation/events/GuiScreenOverlayHandler.java
@@ -68,26 +68,20 @@ public class GuiScreenOverlayHandler extends WContainer implements IGui {
 
     public List<GuiCraftMini> inventoryToWidgets(Inventory inventory) {
         List<GuiCraftMini> results = new ArrayList<>();
-        if (Controller.isServerActive())
-        {
-            for (int i = 0; i < inventory.items.size(); i++)
-            {
+        if (Controller.isServerActive()) {
+            for (int i = 0; i < inventory.items.size(); i++) {
                 ItemStack itemStack = inventory.items.get(i);
-                if (itemStack.getItem() == JecaItem.CRAFT.get())
-                {
+                if (itemStack.getItem() == JecaItem.CRAFT.get()) {
                     GuiCraftMini widget = new GuiCraftMini(itemStack, i);
-                    if (widget.record.overlayOpen)
-                    {
+                    if (widget.record.overlayOpen) {
                         results.add(widget);
                     }
                 }
             }
         }
-        else
-        {
+        else {
             GuiCraftMini widget = new GuiCraftMini(null, 0);
-            if (widget.record.overlayOpen)
-            {
+            if (widget.record.overlayOpen) {
                 results.add(widget);
             }
         }

--- a/common/src/main/java/me/towdium/jecalculation/gui/JecaGui.java
+++ b/common/src/main/java/me/towdium/jecalculation/gui/JecaGui.java
@@ -148,7 +148,7 @@ public class JecaGui extends AbstractContainerScreen<JecaGui.JecaContainer> {
 
     public int getGlobalMouseX() {
         Minecraft mc = Objects.requireNonNull(Minecraft.getInstance(), "Internal error");
-        int width = mc.getWindow().getWidth() / 2;
+        int width = mc.getWindow().getWidth();
         if (width == 0) {
             return 0;
         }
@@ -157,7 +157,7 @@ public class JecaGui extends AbstractContainerScreen<JecaGui.JecaContainer> {
 
     public int getGlobalMouseY() {
         Minecraft mc = Objects.requireNonNull(Minecraft.getInstance(), "Internal error");
-        int height = mc.getWindow().getHeight() / 2;
+        int height = mc.getWindow().getHeight();
         if (height == 0) {
             return 0;
         }


### PR DESCRIPTION
1. Fixed mouse position being multiplied by two when using calculator widget.
2. Fixed incorrect behavior in client mode, where instead of creating a widget if a player has enabled the option, it would create as many widgets as the number of calculators player had. This meant that without a calculator you couldn't see the widget and with multiple calculators, every time you would open an inventory you would get multiple widgets spawned in the same place.