### PR TITLE
Update to 1.20.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "architectury-plugin" version "3.4-SNAPSHOT"
-    id "dev.architectury.loom" version "1.3-SNAPSHOT" apply false
+    id "dev.architectury.loom" version "1.5-SNAPSHOT" apply false
 }
 
 architectury {
@@ -19,7 +19,7 @@ subprojects {
         // The following line declares the mojmap mappings, you may use other mappings as well
         mappings loom.layered() {
             officialMojangMappings()
-            parchment("org.parchmentmc.data:parchment-1.20.1:2023.09.03@zip")
+            parchment("org.parchmentmc.data:parchment-1.20.4:2024.02.25@zip")
         }
         // The following line declares the yarn mappings you may select this one as well.
         // mappings "net.fabricmc:yarn:1.20.1+build.10:v2"

--- a/common/src/main/java/me/towdium/jecalculation/compat/jei/JecaJEIPlugin.java
+++ b/common/src/main/java/me/towdium/jecalculation/compat/jei/JecaJEIPlugin.java
@@ -106,7 +106,7 @@ public class JecaJEIPlugin implements IModPlugin {
     public void onRuntimeAvailable(IJeiRuntime jeiRuntime) {
         runtime = jeiRuntime;
         ModCompat.isJEILoaded = true;
-        if (Platform.isForge())
+        if (Platform.isForgeLike())
             try {
                 FORGE_FLUID_INGREDIENT_CLASS = Class.forName("net.minecraftforge.fluids.FluidStack");
             } catch (ClassNotFoundException e) {

--- a/common/src/main/java/me/towdium/jecalculation/data/label/labels/LFluidStack.java
+++ b/common/src/main/java/me/towdium/jecalculation/data/label/labels/LFluidStack.java
@@ -100,7 +100,7 @@ public class LFluidStack extends LStack<Fluid> {
     public static String format(long amount) {
         float bucket = FluidStackHooks.bucketAmount();
         return amount >= bucket ? Utilities.cutNumber(amount / bucket, 4) + "B"
-                : amount + (Platform.isForge() ? "mB" : "U");
+                : amount + (Platform.isForgeLike() ? "mB" : "U");
     }
 
     @Override

--- a/common/src/main/java/me/towdium/jecalculation/events/GuiScreenEventHandler.java
+++ b/common/src/main/java/me/towdium/jecalculation/events/GuiScreenEventHandler.java
@@ -119,10 +119,10 @@ public class GuiScreenEventHandler {
         return interruptFalse();
     }
 
-    public EventResult onMouseScroll(Minecraft client, Screen screen, double mouseX, double mouseY, double amount) {
+    public EventResult onMouseScroll(Minecraft client, Screen screen, double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
         if (overlayHandler == null || !isScreenValidForOverlay(screen))
             return pass();
-        return amount != 0 && overlayHandler.onMouseScroll(gui, gui.getGlobalMouseX(), gui.getGlobalMouseY(), (int) amount) ? interruptFalse() : pass();
+        return verticalAmount != 0 && overlayHandler.onMouseScroll(gui, gui.getGlobalMouseX(), gui.getGlobalMouseY(), (int) verticalAmount) ? interruptFalse() : pass();
     }
 
     public EventResult onMouseClicked(Minecraft client, Screen screen, double mouseX, double mouseY, int button) {

--- a/common/src/main/java/me/towdium/jecalculation/gui/JecaGui.java
+++ b/common/src/main/java/me/towdium/jecalculation/gui/JecaGui.java
@@ -214,13 +214,13 @@ public class JecaGui extends AbstractContainerScreen<JecaGui.JecaContainer> {
     }
 
 
-    public static EventResult onMouseScroll(Minecraft client, Screen screen, double mouseX, double mouseY, double amount) {
+    public static EventResult onMouseScroll(Minecraft client, Screen screen, double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
         if (!(screen instanceof JecaGui)) return pass();
         JecaGui gui = getCurrent();
         int xMouse = getMouseX();
         int yMouse = getMouseY();
-        if (amount != 0)
-            gui.root.onMouseScroll(gui, xMouse, yMouse, (int) amount);
+        if (verticalAmount != 0)
+            gui.root.onMouseScroll(gui, xMouse, yMouse, (int) verticalAmount);
         return pass();
     }
 
@@ -242,10 +242,10 @@ public class JecaGui extends AbstractContainerScreen<JecaGui.JecaContainer> {
         return pass();
     }
 
-    @Override
-    public void containerTick() {
-        root.onTick(this);
-    }
+//    @Override
+//    public void containerTick() {
+//        root.onTick(this);
+//    }
 
     @Nullable
     public Slot getSlotUnderMouse() {
@@ -393,7 +393,7 @@ public class JecaGui extends AbstractContainerScreen<JecaGui.JecaContainer> {
 
     @Override
     protected void renderBg(GuiGraphics matrixGraphics, float partialTicks, int x, int y) {
-        renderBackground(matrixGraphics);
+//        renderBackground(matrixGraphics);
     }
 
     @Override

--- a/common/src/main/java/me/towdium/jecalculation/gui/guis/pickers/PickerItemStack.java
+++ b/common/src/main/java/me/towdium/jecalculation/gui/guis/pickers/PickerItemStack.java
@@ -46,7 +46,7 @@ public class PickerItemStack extends IPicker.Impl implements IGui {
 
     public void update(ILabel l) {
         raw = l;
-        setFCap(!Platform.isForge());
+        setFCap(!Platform.isForgeLike());
         setFMeta(false);
         setFNbt(false);
         boolean b = l == ILabel.EMPTY;
@@ -65,7 +65,7 @@ public class PickerItemStack extends IPicker.Impl implements IGui {
     }
 
     private void setFCap(boolean b) {
-        if (Platform.isForge())
+        if (Platform.isForgeLike())
             setF(b, bCapN, bCapF, () -> fCap = b);
     }
 

--- a/common/src/main/java/me/towdium/jecalculation/gui/widgets/IWidget.java
+++ b/common/src/main/java/me/towdium/jecalculation/gui/widgets/IWidget.java
@@ -62,8 +62,8 @@ public interface IWidget {
         return false;
     }
 
-    default void onTick(JecaGui gui) {
-    }
+//    default void onTick(JecaGui gui) {
+//    }
 
     @FunctionalInterface
     interface ListenerValue<W extends IWidget, V> {

--- a/common/src/main/java/me/towdium/jecalculation/gui/widgets/WContainer.java
+++ b/common/src/main/java/me/towdium/jecalculation/gui/widgets/WContainer.java
@@ -138,8 +138,8 @@ public class WContainer implements IContainer {
                 .anyMatch(i -> i.getLabelUnderMouse(xMouse - offsetX, yMouse - offsetY, label));
     }
 
-    @Override
-    public void onTick(JecaGui gui) {
-        widgets.forEach(i -> i.onTick(gui));
-    }
+//    @Override
+//    public void onTick(JecaGui gui) {
+//        widgets.forEach(i -> i.onTick(gui));
+//    }
 }

--- a/common/src/main/java/me/towdium/jecalculation/gui/widgets/WTextField.java
+++ b/common/src/main/java/me/towdium/jecalculation/gui/widgets/WTextField.java
@@ -36,10 +36,10 @@ public class WTextField implements IWidget {
         textField.mouseClicked(xMouse, yMouse, button);
     }
 
-    @Override
-    public void onTick(JecaGui gui) {
-        textField.tick();
-    }
+//    @Override
+//    public void onTick(JecaGui gui) {
+//        textField.tick();
+//    }
 
     @Override
     public boolean onMouseClicked(JecaGui gui, int xMouse, int yMouse, int button) {

--- a/common/src/main/java/me/towdium/jecalculation/utils/Utilities.java
+++ b/common/src/main/java/me/towdium/jecalculation/utils/Utilities.java
@@ -144,14 +144,14 @@ public class Utilities {
         throw new AssertionError();
     }
 
-    public static TagKey<Item> IRON_INGOTS = tag(Registries.ITEM, Platform.isForge() ? "ingots/iron" : "iron_ingots");
+    public static TagKey<Item> IRON_INGOTS = tag(Registries.ITEM, Platform.isForgeLike() ? "ingots/iron" : "iron_ingots");
 
     public static <T> TagKey<T> tag(ResourceKey<? extends Registry<T>> key, String tag) {
         return TagKey.create(key, new ResourceLocation(getTagNamespace(), tag));
     }
 
     public static String getTagNamespace() {
-        return Platform.isForge() ? "forge" : "c";
+        return Platform.isForgeLike() ? "forge" : "c";
     }
 
     // MOD NAME

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,21 +1,21 @@
 org.gradle.jvmargs=-Xmx2048M
 
-minecraft_version=1.20.1
+minecraft_version=1.20.4
 enabled_platforms=quilt,fabric,forge
 
 archives_base_name=jecalculation
 mod_version=4.0.4
 maven_group=me.towdium.jecalculation
 
-architectury_version=9.1.12
+architectury_version=11.1.13
 
-fabric_loader_version=0.14.23
-fabric_api_version=0.90.4+1.20.1
+fabric_loader_version=0.15.7
+fabric_api_version=0.96.4+1.20.4
 
-forge_version=1.20.1-47.2.1
+forge_version=1.20.4-49.0.30
 
-quilt_loader_version=0.21.2-beta.2
+quilt_loader_version=0.24.0-beta.8
 quilt_fabric_api_version=7.4.0+0.90.0-1.20.1
 
-jei_version=15.2.0.27
-rei_version=12.0.684
+jei_version=17.3.0.49
+rei_version=14.0.688


### PR DESCRIPTION
Updated JEC to 1.20.4

Replaced deprecated methods, and added new required parameters.

From what I could find with testing, `containerTick()`, `onTick()` and `renderBg()` are no longer required.

The handling of the blinking cursor seems to now be handled internally within the game, along with the application of the tinted background.

`renderBg()` is now an empty method. Completely removing this method requires changing the `JecaGui` class' declaration(?) which I am not familiar enough with at this time. Whether the method is essential or not is unknown to me, as testing showed this function was called several times. Visually comparing to `1.20.1` and `1.20.4` yielded no conclusive answer.

Issues / Notes:
- Attempting to `runClient` with Forge fails on load. Build seems to function when tested manually. Seems to be Architechtury issue?
- Quilt Fabric API is currently stuck on `1.20.1`. Developers stated a `1.20.4` release is coming soon.

Either a new branch should be made for `1.20.4` or `1.20.1` should be replaced.