### PR TITLE
[Fix] Recipes lost on respawn due to onCloneCapability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "architectury-plugin" version "3.4-SNAPSHOT"
-    id "dev.architectury.loom" version "1.3-SNAPSHOT" apply false
+    id "dev.architectury.loom" version "1.7-SNAPSHOT" apply false
 }
 
 architectury {

--- a/common/src/main/java/me/towdium/jecalculation/data/structure/Recipes.java
+++ b/common/src/main/java/me/towdium/jecalculation/data/structure/Recipes.java
@@ -30,9 +30,9 @@ public class Recipes {
     public Recipes() {
         File file = new File(Utilities.config(), "records.json");
         CompoundTag nbt = Utilities.Json.read(file);
-        if (nbt == null) JustEnoughCalculation.logger.info("Failed to load default records at " + file + ".");
+        if (nbt == null) JustEnoughCalculation.logger.info("No (optional) default records file found at: '" + file + "'");
         else {
-            JustEnoughCalculation.logger.info("Loading default records at " + file + ".");
+            JustEnoughCalculation.logger.info("Loading default records from " + file + ".");
             deserialize(nbt);
         }
     }

--- a/forge/src/main/java/me/towdium/jecalculation/forge/JecaCapability.java
+++ b/forge/src/main/java/me/towdium/jecalculation/forge/JecaCapability.java
@@ -54,8 +54,10 @@ public class JecaCapability {
 
     @SubscribeEvent
     public static void onCloneCapability(PlayerEvent.Clone e) {
+        e.getOriginal().reviveCaps();
         RecordPlayer r = JecaCapability.getRecord(e.getOriginal());
-        e.getOriginal().getCapability(JecaCapability.CAPABILITY_RECORD, Direction.UP).orElseGet(Container::new).setRecord(r);
+        e.getEntity().getCapability(JecaCapability.CAPABILITY_RECORD, Direction.UP).orElseGet(Container::new).setRecord(r);
+        e.getOriginal().invalidateCaps();
     }
 
     public static class Container {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,18 +4,18 @@ minecraft_version=1.20.1
 enabled_platforms=quilt,fabric,forge
 
 archives_base_name=jecalculation
-mod_version=4.0.4
+mod_version=4.0.5
 maven_group=me.towdium.jecalculation
 
-architectury_version=9.1.12
+architectury_version=9.2.14
 
-fabric_loader_version=0.14.23
-fabric_api_version=0.90.4+1.20.1
+fabric_loader_version=0.16.9
+fabric_api_version=0.92.2+1.20.1
 
-forge_version=1.20.1-47.2.1
+forge_version=1.20.1-47.3.12
 
-quilt_loader_version=0.21.2-beta.2
-quilt_fabric_api_version=7.4.0+0.90.0-1.20.1
+quilt_loader_version=0.28.0-beta.3
+quilt_fabric_api_version=7.7.0+0.92.2-1.20.1
 
 jei_version=15.2.0.27
 rei_version=12.0.684

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Capabilities attached to the player are lost on respawn because they weren't being passed to the new RecordPlayer object correctly. This leaves the player's recipe list empty in memory. When the player leaves, the empty recipe list is written to the save data erasing all previously-stored recipes.

This needs to be backported to other applicable branches (like 1.18)
This also fixes issues #170 and probably #156 